### PR TITLE
feat(ssh-cli): add ssh CLI based wrapper Runner implementation

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,0 +1,5 @@
+package runner
+
+import "errors"
+
+var Err = errors.New("runner")

--- a/ssh_cli.go
+++ b/ssh_cli.go
@@ -1,0 +1,133 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+)
+
+var (
+	ErrSSHCLI              = fmt.Errorf("%w: sshcli: ", Err)
+	ErrSSHCLINoDestination = fmt.Errorf(
+		"%w: destination must be set", ErrSSHCLI,
+	)
+)
+
+// SSHCLI is a Runner that wraps another Runner, essentially prefixing given
+// commands and arguments with "ssh", relevant SSH CLI arguments, and the given
+// destination. It then passes this new "ssh" command to the underlying Runner.
+//
+// This is useful for running commands on remote hosts via SSH, without having
+// to use the Go ssh package.
+//
+// Interactive commands are not supported, meaning SSH password prompts will not
+// work, and the remote machine's hostkey should already be known and trusted by
+// the ssh CLI client.
+type SSHCLI struct {
+	// Runner is the underlying Runner to run commands with, after wrapping them
+	// with ssh. If not set, running commands will cause a panic.
+	Runner Runner
+
+	// Destination is the remote SSH destination to connect to, which may be
+	// specified as either "[user@]hostname" or a URI of the form
+	// "ssh://[user@]hostname[:port]".
+	Destination string
+
+	// Port is the remote SSH port (-p) flag to use. When 0, no -p flag will be
+	// used.
+	Port int
+
+	// IdentityFile is the remote SSH identity file (-i) flag to use. When
+	// empty, no -i flag will be used.
+	IdentityFile string
+
+	// Login is the remote SSH login (-l) flag to use. When empty, no -l flag
+	// will be used.
+	Login string
+
+	// Args is a string slice of extra arguments to pass to ssh.
+	Args []string
+
+	env []string
+}
+
+var _ Runner = &SSHCLI{}
+
+// Run executes the command remotely via ssh by calling Run on the underlying
+// Runner.
+//
+// Will panic if Runner field is nil.
+// Will return a error if Destination field is empty.
+func (rsc *SSHCLI) Run(
+	stdin io.Reader,
+	stdout io.Writer,
+	stderr io.Writer,
+	command string,
+	args ...string,
+) error {
+	sshArgs, err := rsc.args(command, args)
+	if err != nil {
+		return err
+	}
+
+	return rsc.Runner.Run(stdin, stdout, stderr, "ssh", sshArgs...)
+}
+
+// RunContext executes the command remotely via ssh by calling RunContext on the
+// underlying Runner.
+//
+// Will panic if Runner field is nil.
+// Will return a error if Destination field is empty.
+func (rsc *SSHCLI) RunContext(
+	ctx context.Context,
+	stdin io.Reader,
+	stdout io.Writer,
+	stderr io.Writer,
+	command string,
+	args ...string,
+) error {
+	sshArgs, err := rsc.args(command, args)
+	if err != nil {
+		return err
+	}
+
+	return rsc.Runner.RunContext(ctx, stdin, stdout, stderr, "ssh", sshArgs...)
+}
+
+func (rsc *SSHCLI) args(command string, args []string) ([]string, error) {
+	if rsc.Destination == "" {
+		return nil, ErrSSHCLINoDestination
+	}
+
+	sshArgs := []string{}
+
+	if rsc.Port != 0 {
+		sshArgs = append(sshArgs, "-p", strconv.Itoa(rsc.Port))
+	}
+	if rsc.IdentityFile != "" {
+		sshArgs = append(sshArgs, "-i", rsc.IdentityFile)
+	}
+	if rsc.Login != "" {
+		sshArgs = append(sshArgs, "-l", rsc.Login)
+	}
+	if len(rsc.Args) > 0 {
+		sshArgs = append(sshArgs, rsc.Args...)
+	}
+	sshArgs = append(sshArgs, rsc.Destination, "--")
+
+	if len(rsc.env) > 0 {
+		sshArgs = append(sshArgs, "env")
+		sshArgs = append(sshArgs, rsc.env...)
+	}
+	sshArgs = append(sshArgs, command)
+	sshArgs = append(sshArgs, args...)
+
+	return sshArgs, nil
+}
+
+// Env sets the environment by calling Env on the underlying Runner. Will panic
+// if Runner field is nil on SSH instance.
+func (rsc *SSHCLI) Env(env ...string) {
+	rsc.env = env
+}

--- a/ssh_cli_test.go
+++ b/ssh_cli_test.go
@@ -1,0 +1,726 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	mock_runner "github.com/krystal/go-runner/mock"
+	"github.com/romdo/gomockctx"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSSHCLI_Run(t *testing.T) {
+	type fields struct {
+		Destination  string
+		Port         int
+		IdentityFile string
+		Login        string
+		Args         []string
+	}
+	type args struct {
+		stdin   io.Reader
+		stdout  io.Writer
+		stderr  io.Writer
+		command string
+		args    []string
+	}
+	tests := []struct {
+		name        string
+		env         []string
+		fields      fields
+		args        args
+		err         error
+		wantCommand string
+		wantArgs    []string
+		wantErr     string
+	}{
+		{
+			name: "ssh hostname",
+			fields: fields{
+				Destination: "narnia.local",
+			},
+			args: args{
+				stdin:   nil,
+				stdout:  &bytes.Buffer{},
+				stderr:  &bytes.Buffer{},
+				command: "docker",
+				args:    []string{"ps", "-a"},
+			},
+			wantCommand: "ssh",
+			wantArgs: []string{
+				"narnia.local", "--", "docker", "ps", "-a",
+			},
+		},
+		{
+			name: "ssh user@hostname",
+			fields: fields{
+				Destination: "darrin@narnia.local",
+			},
+			args: args{
+				stdin:   nil,
+				stdout:  &bytes.Buffer{},
+				stderr:  &bytes.Buffer{},
+				command: "docker",
+				args:    []string{"ps", "-a"},
+			},
+			wantCommand: "ssh",
+			wantArgs: []string{
+				"darrin@narnia.local", "--", "docker", "ps", "-a",
+			},
+		},
+		{
+			name: "ssh ssh://user@hostname:port",
+			fields: fields{
+				Destination: "ssh://darrin@narnia.local:322",
+			},
+			args: args{
+				stdin:   nil,
+				stdout:  &bytes.Buffer{},
+				stderr:  &bytes.Buffer{},
+				command: "docker",
+				args:    []string{"ps", "-a"},
+			},
+			wantCommand: "ssh",
+			wantArgs: []string{
+				"ssh://darrin@narnia.local:322",
+				"--", "docker", "ps", "-a",
+			},
+		},
+		{
+			name: "stdin",
+			fields: fields{
+				Destination: "narnia.local",
+			},
+			args: args{
+				stdin:   bytes.NewBufferString("foo\nbar"),
+				stdout:  nil,
+				stderr:  nil,
+				command: "docker",
+				args:    []string{"kill", "-s", "HUP"},
+			},
+			wantCommand: "ssh",
+			wantArgs: []string{
+				"narnia.local", "--", "docker", "kill", "-s", "HUP",
+			},
+		},
+		{
+			name: "stdout",
+			fields: fields{
+				Destination: "narnia.local",
+			},
+			args: args{
+				stdin:   nil,
+				stdout:  &bytes.Buffer{},
+				stderr:  nil,
+				command: "docker",
+				args:    []string{"stop", "foo"},
+			},
+			wantCommand: "ssh",
+			wantArgs: []string{
+				"narnia.local", "--", "docker", "stop", "foo",
+			},
+		},
+		{
+			name: "stderr",
+			fields: fields{
+				Destination: "narnia.local",
+			},
+			args: args{
+				stdin:   nil,
+				stdout:  nil,
+				stderr:  &bytes.Buffer{},
+				command: "docker",
+				args:    []string{"stop", "foo"},
+			},
+			wantCommand: "ssh",
+			wantArgs: []string{
+				"narnia.local", "--", "docker", "stop", "foo",
+			},
+		},
+		{
+			name: "with Port",
+			fields: fields{
+				Destination: "narnia.local",
+				Port:        322,
+			},
+			args: args{
+				stdin:   nil,
+				stdout:  &bytes.Buffer{},
+				stderr:  &bytes.Buffer{},
+				command: "docker",
+				args:    []string{"ps", "-a"},
+			},
+			wantCommand: "ssh",
+			wantArgs: []string{
+				"-p", "322", "narnia.local", "--", "docker", "ps", "-a",
+			},
+		},
+		{
+			name: "with IdentityFile",
+			fields: fields{
+				Destination:  "narnia.local",
+				IdentityFile: "/home/darrin/.ssh/id_other",
+			},
+			args: args{
+				stdin:   nil,
+				stdout:  &bytes.Buffer{},
+				stderr:  &bytes.Buffer{},
+				command: "docker",
+				args:    []string{"ps", "-a"},
+			},
+			wantCommand: "ssh",
+			wantArgs: []string{
+				"-i", "/home/darrin/.ssh/id_other", "narnia.local",
+				"--", "docker", "ps", "-a",
+			},
+		},
+		{
+			name: "with Login",
+			fields: fields{
+				Destination: "narnia.local",
+				Login:       "barfoo",
+			},
+			args: args{
+				stdin:   nil,
+				stdout:  &bytes.Buffer{},
+				stderr:  &bytes.Buffer{},
+				command: "docker",
+				args:    []string{"ps", "-a"},
+			},
+			wantCommand: "ssh",
+			wantArgs: []string{
+				"-l", "barfoo", "narnia.local", "--", "docker", "ps", "-a",
+			},
+		},
+		{
+			name: "with Env",
+			env:  []string{"FOO=BAR", "PORT=8080"},
+			fields: fields{
+				Destination: "narnia.local",
+			},
+			args: args{
+				stdin:   nil,
+				stdout:  &bytes.Buffer{},
+				stderr:  &bytes.Buffer{},
+				command: "myapp",
+				args:    []string{"run", "-a"},
+			},
+			wantCommand: "ssh",
+			wantArgs: []string{
+				"narnia.local",
+				"--", "env", "FOO=BAR", "PORT=8080", "myapp", "run", "-a",
+			},
+		},
+		{
+			name: "with Args",
+			fields: fields{
+				Destination: "narnia.local",
+				Args:        []string{"-C", "-o", "AddKeysToAgent=yes"},
+			},
+			args: args{
+				stdin:   nil,
+				stdout:  &bytes.Buffer{},
+				stderr:  &bytes.Buffer{},
+				command: "docker",
+				args:    []string{"ps", "-a"},
+			},
+			wantCommand: "ssh",
+			wantArgs: []string{
+				"-C", "-o", "AddKeysToAgent=yes", "narnia.local",
+				"--", "docker", "ps", "-a",
+			},
+		},
+		{
+			name: "with Port, IdentityFile, Login, Args and Env",
+			env:  []string{"FOO=BAR", "PORT=8080"},
+			fields: fields{
+				Destination:  "narnia.local",
+				Port:         322,
+				IdentityFile: "/home/darrin/.ssh/id_other",
+				Login:        "barfoo",
+				Args:         []string{"-C", "-o", "AddKeysToAgent=yes"},
+			},
+			args: args{
+				stdin:   nil,
+				stdout:  &bytes.Buffer{},
+				stderr:  &bytes.Buffer{},
+				command: "docker",
+				args:    []string{"ps", "-a"},
+			},
+			wantCommand: "ssh",
+			wantArgs: []string{
+				"-p", "322",
+				"-i", "/home/darrin/.ssh/id_other",
+				"-l", "barfoo",
+				"-C", "-o", "AddKeysToAgent=yes",
+				"narnia.local",
+				"--", "env", "FOO=BAR", "PORT=8080", "docker", "ps", "-a",
+			},
+		},
+		{
+			name:   "no destination",
+			fields: fields{},
+			args: args{
+				stdin:   nil,
+				stdout:  &bytes.Buffer{},
+				stderr:  &bytes.Buffer{},
+				command: "zfs",
+				args:    []string{"list"},
+			},
+			wantErr: ErrSSHCLINoDestination.Error(),
+		},
+		{
+			name: "error",
+			fields: fields{
+				Destination: "narnia.local",
+			},
+			args: args{
+				stdin:   nil,
+				stdout:  &bytes.Buffer{},
+				stderr:  &bytes.Buffer{},
+				command: "zfs",
+				args:    []string{"list"},
+			},
+			err:         errors.New("zfs: command not found"),
+			wantCommand: "ssh",
+			wantArgs:    []string{"narnia.local", "--", "zfs", "list"},
+			wantErr:     "zfs: command not found",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			r := mock_runner.NewMockRunner(ctrl)
+			if tt.wantCommand != "" {
+				r.EXPECT().Run(
+					tt.args.stdin,
+					tt.args.stdout,
+					tt.args.stderr,
+					tt.wantCommand,
+					tt.wantArgs,
+				).Return(tt.err)
+			}
+
+			s := &SSHCLI{
+				Runner:       r,
+				Destination:  tt.fields.Destination,
+				Port:         tt.fields.Port,
+				IdentityFile: tt.fields.IdentityFile,
+				Login:        tt.fields.Login,
+				Args:         tt.fields.Args,
+			}
+
+			if len(tt.env) > 0 {
+				s.Env(tt.env...)
+			}
+
+			err := s.Run(
+				tt.args.stdin,
+				tt.args.stdout,
+				tt.args.stderr,
+				tt.args.command,
+				tt.args.args...,
+			)
+
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSSHCLI_RunContext(t *testing.T) {
+	ctx := gomockctx.New(context.Background())
+
+	type fields struct {
+		Destination  string
+		Port         int
+		IdentityFile string
+		Login        string
+		Args         []string
+	}
+
+	type args struct {
+		ctx     context.Context
+		stdin   io.Reader
+		stdout  io.Writer
+		stderr  io.Writer
+		command string
+		args    []string
+	}
+	tests := []struct {
+		name        string
+		env         []string
+		fields      fields
+		args        args
+		err         error
+		wantCommand string
+		wantArgs    []string
+		wantErr     string
+	}{
+		{
+			name: "ssh hostname",
+			fields: fields{
+				Destination: "narnia.local",
+			},
+			args: args{
+				ctx:     ctx,
+				stdin:   nil,
+				stdout:  &bytes.Buffer{},
+				stderr:  &bytes.Buffer{},
+				command: "docker",
+				args:    []string{"ps", "-a"},
+			},
+			wantCommand: "ssh",
+			wantArgs: []string{
+				"narnia.local", "--", "docker", "ps", "-a",
+			},
+		},
+		{
+			name: "ssh user@hostname",
+			fields: fields{
+				Destination: "darrin@narnia.local",
+			},
+			args: args{
+				ctx:     ctx,
+				stdin:   nil,
+				stdout:  &bytes.Buffer{},
+				stderr:  &bytes.Buffer{},
+				command: "docker",
+				args:    []string{"ps", "-a"},
+			},
+			wantCommand: "ssh",
+			wantArgs: []string{
+				"darrin@narnia.local", "--", "docker", "ps", "-a",
+			},
+		},
+		{
+			name: "ssh ssh://user@hostname:port",
+			fields: fields{
+				Destination: "ssh://darrin@narnia.local:322",
+			},
+			args: args{
+				ctx:     ctx,
+				stdin:   nil,
+				stdout:  &bytes.Buffer{},
+				stderr:  &bytes.Buffer{},
+				command: "docker",
+				args:    []string{"ps", "-a"},
+			},
+			wantCommand: "ssh",
+			wantArgs: []string{
+				"ssh://darrin@narnia.local:322",
+				"--", "docker", "ps", "-a",
+			},
+		},
+		{
+			name: "stdin",
+			fields: fields{
+				Destination: "narnia.local",
+			},
+			args: args{
+				ctx:     ctx,
+				stdin:   bytes.NewBufferString("foo\nbar"),
+				stdout:  nil,
+				stderr:  nil,
+				command: "docker",
+				args:    []string{"kill", "-s", "HUP"},
+			},
+			wantCommand: "ssh",
+			wantArgs: []string{
+				"narnia.local", "--", "docker", "kill", "-s", "HUP",
+			},
+		},
+		{
+			name: "stdout",
+			fields: fields{
+				Destination: "narnia.local",
+			},
+			args: args{
+				ctx:     ctx,
+				stdin:   nil,
+				stdout:  &bytes.Buffer{},
+				stderr:  nil,
+				command: "docker",
+				args:    []string{"stop", "foo"},
+			},
+			wantCommand: "ssh",
+			wantArgs: []string{
+				"narnia.local", "--", "docker", "stop", "foo",
+			},
+		},
+		{
+			name: "stderr",
+			fields: fields{
+				Destination: "narnia.local",
+			},
+			args: args{
+				ctx:     ctx,
+				stdin:   nil,
+				stdout:  nil,
+				stderr:  &bytes.Buffer{},
+				command: "docker",
+				args:    []string{"stop", "foo"},
+			},
+			wantCommand: "ssh",
+			wantArgs: []string{
+				"narnia.local", "--", "docker", "stop", "foo",
+			},
+		},
+		{
+			name: "with Port",
+			fields: fields{
+				Destination: "narnia.local",
+				Port:        322,
+			},
+			args: args{
+				ctx:     ctx,
+				stdin:   nil,
+				stdout:  &bytes.Buffer{},
+				stderr:  &bytes.Buffer{},
+				command: "docker",
+				args:    []string{"ps", "-a"},
+			},
+			wantCommand: "ssh",
+			wantArgs: []string{
+				"-p", "322", "narnia.local", "--", "docker", "ps", "-a",
+			},
+		},
+		{
+			name: "with IdentityFile",
+			fields: fields{
+				Destination:  "narnia.local",
+				IdentityFile: "/home/darrin/.ssh/id_other",
+			},
+			args: args{
+				ctx:     ctx,
+				stdin:   nil,
+				stdout:  &bytes.Buffer{},
+				stderr:  &bytes.Buffer{},
+				command: "docker",
+				args:    []string{"ps", "-a"},
+			},
+			wantCommand: "ssh",
+			wantArgs: []string{
+				"-i", "/home/darrin/.ssh/id_other", "narnia.local",
+				"--", "docker", "ps", "-a",
+			},
+		},
+		{
+			name: "with Login",
+			fields: fields{
+				Destination: "narnia.local",
+				Login:       "barfoo",
+			},
+			args: args{
+				ctx:     ctx,
+				stdin:   nil,
+				stdout:  &bytes.Buffer{},
+				stderr:  &bytes.Buffer{},
+				command: "docker",
+				args:    []string{"ps", "-a"},
+			},
+			wantCommand: "ssh",
+			wantArgs: []string{
+				"-l", "barfoo", "narnia.local", "--", "docker", "ps", "-a",
+			},
+		},
+		{
+			name: "with Env",
+			env:  []string{"FOO=BAR", "PORT=8080"},
+			fields: fields{
+				Destination: "narnia.local",
+			},
+			args: args{
+				ctx:     ctx,
+				stdin:   nil,
+				stdout:  &bytes.Buffer{},
+				stderr:  &bytes.Buffer{},
+				command: "myapp",
+				args:    []string{"run", "-a"},
+			},
+			wantCommand: "ssh",
+			wantArgs: []string{
+				"narnia.local",
+				"--", "env", "FOO=BAR", "PORT=8080", "myapp", "run", "-a",
+			},
+		},
+		{
+			name: "with Args",
+			fields: fields{
+				Destination: "narnia.local",
+				Args:        []string{"-C", "-o", "AddKeysToAgent=yes"},
+			},
+			args: args{
+				ctx:     ctx,
+				stdin:   nil,
+				stdout:  &bytes.Buffer{},
+				stderr:  &bytes.Buffer{},
+				command: "docker",
+				args:    []string{"ps", "-a"},
+			},
+			wantCommand: "ssh",
+			wantArgs: []string{
+				"-C", "-o", "AddKeysToAgent=yes", "narnia.local",
+				"--", "docker", "ps", "-a",
+			},
+		},
+		{
+			name: "with Port, IdentityFile, Login, Args and Env",
+			env:  []string{"FOO=BAR", "PORT=8080"},
+			fields: fields{
+				Destination:  "narnia.local",
+				Port:         322,
+				IdentityFile: "/home/darrin/.ssh/id_other",
+				Login:        "barfoo",
+				Args:         []string{"-C", "-o", "AddKeysToAgent=yes"},
+			},
+			args: args{
+				ctx:     ctx,
+				stdin:   nil,
+				stdout:  &bytes.Buffer{},
+				stderr:  &bytes.Buffer{},
+				command: "docker",
+				args:    []string{"ps", "-a"},
+			},
+			wantCommand: "ssh",
+			wantArgs: []string{
+				"-p", "322",
+				"-i", "/home/darrin/.ssh/id_other",
+				"-l", "barfoo",
+				"-C", "-o", "AddKeysToAgent=yes",
+				"narnia.local",
+				"--", "env", "FOO=BAR", "PORT=8080", "docker", "ps", "-a",
+			},
+		},
+		{
+			name:   "no destination",
+			fields: fields{},
+			args: args{
+				ctx:     ctx,
+				stdin:   nil,
+				stdout:  &bytes.Buffer{},
+				stderr:  &bytes.Buffer{},
+				command: "zfs",
+				args:    []string{"list"},
+			},
+			wantErr: ErrSSHCLINoDestination.Error(),
+		},
+		{
+			name: "error",
+			fields: fields{
+				Destination: "narnia.local",
+			},
+			args: args{
+				ctx:     ctx,
+				stdin:   nil,
+				stdout:  &bytes.Buffer{},
+				stderr:  &bytes.Buffer{},
+				command: "zfs",
+				args:    []string{"list"},
+			},
+			err:         errors.New("zfs: command not found"),
+			wantCommand: "ssh",
+			wantArgs:    []string{"narnia.local", "--", "zfs", "list"},
+			wantErr:     "zfs: command not found",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			r := mock_runner.NewMockRunner(ctrl)
+			if tt.wantCommand != "" {
+				r.EXPECT().RunContext(
+					gomockctx.Eq(tt.args.ctx),
+					tt.args.stdin,
+					tt.args.stdout,
+					tt.args.stderr,
+					tt.wantCommand,
+					tt.wantArgs,
+				).Return(tt.err)
+			}
+
+			s := &SSHCLI{
+				Runner:       r,
+				Destination:  tt.fields.Destination,
+				Port:         tt.fields.Port,
+				IdentityFile: tt.fields.IdentityFile,
+				Login:        tt.fields.Login,
+				Args:         tt.fields.Args,
+			}
+
+			if len(tt.env) > 0 {
+				s.Env(tt.env...)
+			}
+
+			err := s.RunContext(
+				tt.args.ctx,
+				tt.args.stdin,
+				tt.args.stdout,
+				tt.args.stderr,
+				tt.args.command,
+				tt.args.args...,
+			)
+
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSSHCLI_Env(t *testing.T) {
+	type args struct {
+		env []string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "empty",
+			args: args{
+				env: []string{},
+			},
+		},
+		{
+			name: "one var",
+			args: args{
+				env: []string{
+					"foo=bar",
+				},
+			},
+		},
+		{
+			name: "many vars",
+			args: args{
+				env: []string{
+					"foo=bar",
+					"foo=bar",
+					"foz=baz",
+					"nope=why",
+					"hello=world",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			r := mock_runner.NewMockRunner(ctrl)
+
+			s := &SSHCLI{Runner: r}
+			s.Env(tt.args.env...)
+
+			assert.Equal(t, tt.args.env, s.env)
+		})
+	}
+}


### PR DESCRIPTION
SSHCLI is a Runner that wraps another Runner, essentially prefixing given commands and arguments with "ssh", relevant SSH CLI arguments, and the given destination. It then passes this new "ssh" command to the underlying Runner.

This is useful for running commands on remote hosts via SSH, without having to use the Go ssh package.

Interactive commands are not supported, meaning SSH password prompts will not work, and the remote machine's hostkey should already be known and trusted by the ssh CLI client.